### PR TITLE
fix(docker): use shadow JAR for fat JAR with dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/root/.gradle/caches,sharing=locked \
       ./gradlew --no-daemon --stacktrace \
         -Pgithub.user="${GITHUB_USER}" \
         -Pgithub.token="${token}" \
-        build -x test \
+        shadowJar \
     '
 
 FROM gcr.io/distroless/java25-debian13 AS runtime
@@ -28,7 +28,7 @@ WORKDIR /minestom
 
 USER nonroot:nonroot
 
-COPY --from=build --chown=nonroot:nonroot /workspace/build/libs/*.jar /minestom/minestom-lobby.jar
+COPY --from=build --chown=nonroot:nonroot /workspace/build/libs/*-all.jar /minestom/minestom-lobby.jar
 
 EXPOSE 30066
 ENTRYPOINT ["java", "-jar", "/minestom/minestom-lobby.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gg.grounds.root") version "0.1.1"
+    id("com.gradleup.shadow") version "8.3.6"
     application
 }
 


### PR DESCRIPTION
# Pull Request

## Description
The Dockerfile copied the plain JAR from `build/libs` which lacks bundled dependencies and a proper Main-Class manifest. This adds the Shadow plugin to produce a fat JAR and updates the Dockerfile to build via `shadowJar` and copy the `*-all.jar`.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues
- N/A

## Testing
- [ ] Unit tests pass
- [x] Manual testing completed
- [ ] New tests added for new functionality

## Checklist
- [x] I have performed a self-review of my own code
- [ ] Tests have been added/updated and pass (if needed)
- [ ] Documentation has been updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)