### PR TITLE
feat: integrate plugin-agones-minestom for gameserver lifecycle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,21 @@ plugins {
 
 application { mainClass.set("gg.grounds.minestom.lobby.MainKt") }
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/*")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
+}
+
 dependencies {
     implementation("net.minestom:minestom:2026.01.08-1.21.11")
     implementation("com.github.ajalt.clikt:clikt:5.0.1")
+    implementation("gg.grounds:plugin-agones-minestom:0.2.0")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
 }

--- a/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
@@ -1,5 +1,6 @@
 package gg.grounds.minestom.lobby
 
+import gg.grounds.GroundsPluginAgones
 import net.minestom.server.Auth
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
@@ -79,6 +80,8 @@ object LobbyServer {
         globalEventHandler.addListener<PlayerDisconnectEvent>() {
             println("${it.player.uuid}/${it.player.username} left the server")
         }
+
+        GroundsPluginAgones().enable()
 
         minecraftServer.start(address, port)
 


### PR DESCRIPTION
## Summary

Wires up the new `plugin-agones-minestom` module so the lobby gameserver reports its `Ready` / `Allocated` state to the Agones sidecar based on player count.

- `build.gradle.kts`: adds the groundsgg GitHub Packages repository and depends on `plugin-agones-minestom:0.2.0`. Adds `logback-classic` as a runtime SLF4J binding so the plugin's logs appear in stdout.
- `lobby.kt`: calls `GroundsPluginAgones().enable()` right before `minecraftServer.start(...)`. The plugin registers its own `PlayerSpawn` / `PlayerDisconnect` listeners and the 10s fallback reconcile task.

## ⚠️ Draft — blocked

This PR depends on:

1. [groundsgg/plugin-agones#25](https://github.com/groundsgg/plugin-agones/pull/25) merging to introduce the `plugin-agones-minestom` module.
2. A `plugin-agones` release cut (expected `v0.2.0`) so the artifact is published to GitHub Packages.

Until then CI will fail on dependency resolution. Marking the PR as draft.

## Test plan

- [x] `./gradlew build` locally against `plugin-agones-minestom:local-SNAPSHOT` (via `publishToMavenLocal`) — compiles, spotless passes
- [ ] In-cluster smoke test: lobby pod reaches Agones `Ready` after start, transitions to `Allocated` on first player join, returns to `Ready` on last player disconnect
- [ ] Verify logback output: plugin INFO logs (`Minestom Agones plugin initialized`, state transitions) appear in pod stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)