### PR TITLE
feat: integrate plugin-chat-minestom for cross-server chat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,21 @@ plugins {
 
 application { mainClass.set("gg.grounds.minestom.lobby.MainKt") }
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/*")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
+}
+
 dependencies {
     implementation("net.minestom:minestom:2026.01.08-1.21.11")
     implementation("com.github.ajalt.clikt:clikt:5.0.1")
+    implementation("gg.grounds:plugin-chat-minestom:local-SNAPSHOT")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
 }

--- a/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
@@ -1,5 +1,6 @@
 package gg.grounds.minestom.lobby
 
+import gg.grounds.chat.minestom.GroundsChatMinestom
 import net.minestom.server.Auth
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
@@ -79,6 +80,8 @@ object LobbyServer {
         globalEventHandler.addListener<PlayerDisconnectEvent>() {
             println("${it.player.uuid}/${it.player.username} left the server")
         }
+
+        GroundsChatMinestom(globalEventHandler).enable()
 
         minecraftServer.start(address, port)
 


### PR DESCRIPTION
## Summary

Wires up `plugin-chat-minestom` so chat messages on the lobby flow into the Grounds cluster-wide chat bus.

- `build.gradle.kts`: adds the groundsgg GitHub Packages repository and depends on `plugin-chat-minestom:local-SNAPSHOT`. Adds `logback-classic` as a runtime SLF4J binding.
- `lobby.kt`: instantiates `GroundsChatMinestom(globalEventHandler).enable()` right before `minecraftServer.start(...)`. The plugin registers `PlayerChatEvent` (cancel + forward) and `PlayerSpawnEvent` (group announce).

## How cross-server chat works

```
Lobby (minestom) ──pluginmsg──▶ Velocity ──NATS──▶ Velocity on other proxies ──pluginmsg──▶ other gameservers
```

The minestom lobby does **not** talk to NATS directly — it just publishes a `ChatPluginMessage` on the `grounds:chat` channel. The NATS hub lives in `plugin-chat-velocity` on the proxy.

## Fleet env (already set in `pulumi/gitops/fleet/gameserver/lobby-fleet.yaml`)

- `CHAT_GLOBAL_ENABLED=true` — forward global chat to velocity
- `CHAT_GROUP=lobby` — group-announce identifier for first-spawn

## ⚠️ Draft — blocked

`plugin-chat` has no release yet — the dep is pinned to `local-SNAPSHOT`. To test locally:

```bash
cd plugin-chat && ./gradlew publishToMavenLocal
cd minestom-lobby && ./gradlew build
```

Before this PR can merge:

1. plugin-chat needs its WIP committed, a release cut, and the artifact published to GitHub Packages.
2. Swap `local-SNAPSHOT` to the released version.

## Test plan

- [x] `./gradlew build` against `plugin-chat-minestom:local-SNAPSHOT` — compiles, spotless passes
- [ ] In-cluster smoke test: type a message on the lobby → appears in the lobby's own chat (broadcastLocal path when `CHAT_GLOBAL_ENABLED=false`)
- [ ] Cross-server: `CHAT_GLOBAL_ENABLED=true`, two lobby pods + velocity + NATS running → message from lobby A visible on lobby B
- [ ] Cross-platform: chat from minestom lobby visible on paper gameservers (and vice versa)
- [ ] Group-announce: first spawn produces a `GROUP_ANNOUNCE` plugin message with `group=lobby`

🤖 Generated with [Claude Code](https://claude.com/claude-code)