### PR TITLE
feat(agones): register the lobby as an Agones GameServer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,21 @@ plugins {
 
 application { mainClass.set("gg.grounds.minestom.lobby.MainKt") }
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/*")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
+}
+
 dependencies {
     implementation("net.minestom:minestom:2026.01.08-1.21.11")
     implementation("com.github.ajalt.clikt:clikt:5.0.1")
+    implementation("gg.grounds:plugin-agones-minestom:0.5.0")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
 }

--- a/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
@@ -1,5 +1,6 @@
 package gg.grounds.minestom.lobby
 
+import gg.grounds.GroundsPluginAgones
 import net.minestom.server.Auth
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
@@ -78,6 +79,16 @@ object LobbyServer {
 
         globalEventHandler.addListener<PlayerDisconnectEvent>() {
             println("${it.player.uuid}/${it.player.username} left the server")
+        }
+
+        // Register as an Agones GameServer only when the SDK sidecar is present.
+        // The Agones webhook sets AGONES_SDK_HTTP_PORT on GameServer pods, so the
+        // lobby calls ready() and Velocity's plugin-agones can discover it. A plain
+        // standalone lobby (e.g. local NO_PROXY dev) has no sidecar; calling ready()
+        // there just loops on connection errors. Mirrors plugin-agones-paper's gate,
+        // which the minestom variant doesn't apply itself.
+        if (!System.getenv("AGONES_SDK_HTTP_PORT").isNullOrBlank()) {
+            GroundsPluginAgones().enable()
         }
 
         minecraftServer.start(address, port)


### PR DESCRIPTION
The bundle runs `minestom-lobby` as an Agones Fleet (bundle 0.6.4), but the
lobby app never calls the Agones SDK, so its GameServer stays `Scheduled` and
Velocity's plugin-agones (which only discovers `Ready` GameServers) finds no
backend → **"no lobby server available."**

This depends on `plugin-agones-minestom` and calls `GroundsPluginAgones().enable()`,
gated on `AGONES_SDK_HTTP_PORT` so a standalone (NO_PROXY) lobby stays inert.

Supersedes stale draft #14 — pins `0.5.0` (MC 26.1.2) instead of `0.2.0` and adds
the sidecar gate that the minestom variant lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)