### PR TITLE
fix: update lobby to MC 26.1.2 and bind the standard 25565 port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ USER nonroot:nonroot
 
 COPY --from=build --chown=nonroot:nonroot /workspace/build/libs/*-all.jar /minestom/minestom-lobby.jar
 
-EXPOSE 30066
+EXPOSE 25565
 ENTRYPOINT ["java", "-jar", "/minestom/minestom-lobby.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation("net.minestom:minestom:2026.01.08-1.21.11")
+    implementation("net.minestom:minestom:2026.06.20-26.1.2")
     implementation("com.github.ajalt.clikt:clikt:5.0.1")
-    implementation("gg.grounds:plugin-agones-minestom:0.5.0")
+    implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
 }

--- a/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/lobby.kt
@@ -51,9 +51,11 @@ object LobbyServer {
             LightingChunk(instance, x, y)
         }
 
-        // Disable day-night cycle
-        instanceContainer.timeRate = 0
-        instanceContainer.time = SUNRISE_TIME
+        // Freeze the day-night cycle at sunrise (minestom 26.1.2 clock API:
+        // the old Instance.timeRate/time setters moved to Instance.defaultClock()).
+        val clock = instanceContainer.defaultClock()!!
+        clock.rate(0f)
+        clock.time(SUNRISE_TIME)
 
         val globalEventHandler = MinecraftServer.getGlobalEventHandler()
 

--- a/src/main/kotlin/gg/grounds/minestom/lobby/main.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/main.kt
@@ -11,7 +11,7 @@ import com.github.ajalt.clikt.parameters.types.int
 class StartLobbyCommand : CliktCommand() {
 
     val address: String by option("--address").help("The address without a port").default("0.0.0.0")
-    val port: Int by option("--port").help("The port").int().default(30066)
+    val port: Int by option("--port").help("The port").int().default(25565)
     val lobbyAuth: LobbyAuthType by
         option("--auth")
             .help("Defines which authentication is used")


### PR DESCRIPTION
Two blockers stopped players actually joining the lobby through the Velocity proxy (after the Agones discovery chain was fixed):

1. **Wrong MC version** → *"Invalid Version, please use 1.21.11"*. The lobby pinned minestom `2026.01.08-1.21.11` (MC 1.21.11) while clients + paper/velocity are on **MC 26.1.2**. Bump minestom → `2026.06.20-26.1.2` and `plugin-agones-minestom` → `0.6.0`. Adapt the day-night freeze to minestom's new clock API (`Instance.timeRate/time` → `Instance.defaultClock().rate()/time()`).

2. **Wrong port** → *"Connection refused"*. The lobby defaulted to `--port 30066`, but the grounds-gamemode Fleet declares `containerPort 25565` and velocity dials `PodIP:25565`. Default the lobby to **25565** (like paper-game) + `EXPOSE 25565`.

Verified: `compileKotlin` + `shadowJar` green against the new deps. Live port fix already confirmed the connection reaches the lobby (was "Connection refused", now "has connected") — this makes it durable and fixes the remaining version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)