### PR TITLE
chore(deps): update plugin permissions to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.2.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
-    implementation("gg.grounds:plugin-permissions-minestom:0.2.0")
+    implementation("gg.grounds:plugin-permissions-minestom:0.3.0")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
# Pull Request

## Description
Update the lobby's Minestom permissions plugin dependency to the released 0.3.0 version.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [x] 🔧 Chore

## Related Issues
- Relates to [library-platform-bundle#43](https://github.com/groundsgg/library-platform-bundle/pull/43)

## Testing
- [x] Unit tests pass: `./gradlew test`
- [x] Formatting: `./gradlew spotlessApply`
- [x] Build: `./gradlew build`
- [ ] Manual testing completed
- [ ] New tests added for new functionality

## Checklist
- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [ ] Documentation has been updated (if needed)