### PR TITLE
feat!: update the lobby to Minecraft 26.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("gg.grounds:grounds-dependencies:0.2.0"))
+    implementation(platform("gg.grounds:grounds-dependencies:1.0.0"))
 
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.2.0")
     implementation("net.minestom:minestom")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("gg.grounds:grounds-dependencies:0.1.0"))
+    implementation(platform("gg.grounds:grounds-dependencies:0.2.0"))
 
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.2.0")
     implementation("net.minestom:minestom")


### PR DESCRIPTION
## What

Bumps `gg.grounds:grounds-dependencies` `0.1.0` → **`0.2.0`**, which moves the managed `net.minestom:minestom` constraint to `2026.07.12-26.2` ([upstream release](https://github.com/Minestom/Minestom/releases/tag/2026.07.12-26.2)).

That is the whole diff — one line. The Minestom version is managed by the BOM, so it does not belong in this repo's `build.gradle.kts`.

**No source changes were needed.** The lobby only touches the instance/generator, the day-night clock and the player events; none of those are among 26.2's 148 binary-incompatible changes.

## Blocked on

groundsgg/grounds-dependencies#3 — **merge and release `grounds-dependencies:0.2.0` first**. CI here stays red until that artifact is published. Draft until then.

## Verification

Built against a locally-published `grounds-dependencies:0.2.0`:

- `./gradlew build` green (compile + tests + spotless).
- Dependency resolution converges on a single `net.minestom:minestom:2026.07.12-26.2` (plus `net.minestom:data:26.2-rv3`); `plugin-agones-minestom 0.6.0`, `plugin-permissions-minestom 0.3.0` and `grounds-minestom-runtime` all get pulled up to 26.2.
- Shadow jar boots: `Starting Grounds (2026.07.12-26.2) server` → `Grounds server started successfully`, lobby module installs, no `NoSuchMethodError`/`NoClassDefFoundError` from the libraries compiled against 26.1.2.
- Server-list ping answers **`{"name": "26.2", "protocol": 776}`**.

## Fleet note

Protocol 776 clients need a proxy that speaks 776. Our Velocity image is on build 601 (2026-06-02) and 26.2 support landed in build 604 — see groundsgg/containers (Velocity → 3.5.1). **Paper backends are still on 26.1.2 / protocol 775 and are not covered by these PRs.**