### PR TITLE
fix(runtime): bump runtime-core to 0.4.0 so permission manifests register

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
-    implementation("gg.grounds:plugin-permissions-minestom:0.3.0")
+    implementation("gg.grounds:plugin-permissions-minestom:0.4.0")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ repositories {
 dependencies {
     implementation(platform("gg.grounds:grounds-dependencies:1.0.0"))
 
-    implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.2.0")
+    implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.3.0")


### PR DESCRIPTION
## Why

The lobby pinned `runtime-core:0.2.0`, which predates `GroundsServerContext.activeModuleProviders` (added in runtime-api 0.3.0).

`plugin-permissions-minestom` calls it — `GroundsPermissionsModule.kt:73` — to discover the permission manifests declared by the active modules.

Because the member compiles to a **real JVM default method** (verified with `javap` on the published runtime-api 0.3.0 jar), the lobby did not blow up with an `AbstractMethodError`. It just silently got `emptyList()` back, so **no module ever registered its permission manifest with the catalog**. Permission *checks* still worked — those come from the snapshot — but the catalog side was dead.

## What

`runtime-core: 0.2.0 → 0.4.0`. The API diff across those versions is purely additive (`GroundsServerContext` +8 lines, `GroundsModuleComposition`, `GroundsServer`); the `GroundsModule`/`GroundsModuleProvider` SPI is unchanged.

## Verification

`./gradlew build` green, and `runtime-api` now resolves to 0.4.0 across the whole graph (previously a 0.2.0/0.3.0 skew).