### PR TITLE
fix: bump plugin-permissions-minestom to 0.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
-    implementation("gg.grounds:plugin-permissions-minestom:0.4.0")
+    implementation("gg.grounds:plugin-permissions-minestom:0.5.0")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
0.5.0 (groundsgg/plugin-permissions#11) adds `Permissions.commandCondition(node)` — the gate a gamemode needs to put a command behind a permission node.

Minestom has no permission API of its own (verified against the pinned jar: zero permission classes, `CommandSender` has no `hasPermission`), so `CommandCondition` is the only native hook, and this is what makes permissions usable on a Minestom server at all.

Keeps the lobby in lockstep with the Velocity proxy, which needs the same release to make `source.hasPermission()` work.