### PR TITLE
fix: resolve vanilla-maps from the repo that actually publishes it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,16 @@ repositories {
             password = providers.gradleProperty("github.token").get()
         }
     }
+    // The `groundsgg/*` wildcard below does NOT serve gg.grounds.vanilla — GitHub Packages
+    // answered it with nothing in CI, and the build fell through to Maven Central and died.
+    // Name the publishing repo explicitly, exactly as plugin-permissions does above.
+    maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/grounds-vanilla")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
     maven {
         url = uri("https://maven.pkg.github.com/groundsgg/*")
         credentials {


### PR DESCRIPTION
The 1.1.0 Docker build failed:

```
Could not find gg.grounds.vanilla:vanilla-maps:0.2.0.
Searched in the following locations:
  - https://repo.maven.apache.org/maven2/...
  - https://maven.pkg.github.com/groundsgg/plugin-permissions/...
  - https://maven.pkg.github.com/groundsgg/*/...
```

The `groundsgg/*` wildcard **does** get queried and returns nothing for `gg.grounds.vanilla` — the packages live in `groundsgg/grounds-vanilla` and only an explicit repo URL reaches them (which is why `plugin-permissions` is named explicitly too). It resolved locally only because the jars were already in the Gradle cache.

There is no image for 1.1.0; this needs a follow-up release.