### PR TITLE
fix: load the lobby map with Minestom's own AnvilLoader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,16 +24,6 @@ repositories {
             password = providers.gradleProperty("github.token").get()
         }
     }
-    // The `groundsgg/*` wildcard below does NOT serve gg.grounds.vanilla — GitHub Packages
-    // answered it with nothing in CI, and the build fell through to Maven Central and died.
-    // Name the publishing repo explicitly, exactly as plugin-permissions does above.
-    maven {
-        url = uri("https://maven.pkg.github.com/groundsgg/grounds-vanilla")
-        credentials {
-            username = providers.gradleProperty("github.user").get()
-            password = providers.gradleProperty("github.token").get()
-        }
-    }
     maven {
         url = uri("https://maven.pkg.github.com/groundsgg/*")
         credentials {
@@ -50,8 +40,9 @@ dependencies {
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.5.0")
-    implementation("gg.grounds.vanilla:vanilla-maps:0.2.0")
-    implementation("gg.grounds.vanilla:vanilla-core:0.2.0")
+    // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
+    // declare it because we use it directly.
+    implementation("com.google.code.gson:gson:2.13.2")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
@@ -1,11 +1,14 @@
 package gg.grounds.minestom.lobby
 
-import gg.grounds.vanilla.map.LoadedMap
-import gg.grounds.vanilla.map.MapInstanceProvider
-import gg.grounds.vanilla.map.MapTemplate
+import com.google.gson.JsonParser
+import java.nio.file.Files
 import java.nio.file.Path
+import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.instance.InstanceContainer
+import net.minestom.server.instance.LightingChunk
+import net.minestom.server.instance.anvil.AnvilLoader
+import net.minestom.server.utils.chunk.ChunkSupplier
 
 private const val SUNRISE_TIME: Long = 6000
 
@@ -15,24 +18,51 @@ private const val SUNRISE_TIME: Long = 6000
 // right next to build.gradle.kts), so the same default works in both places.
 private const val DEFAULT_MAP_PATH = "lobby"
 
+// The map was exported by WorldDownloader, which puts the region files one dimension deep
+// rather than in a top-level region/. AnvilLoader wants the directory that *contains*
+// region/, so descend when that layout is what we got.
+private const val OVERWORLD = "dimensions/minecraft/overworld"
+
 /** The loaded lobby instance and the spawn every joining player is teleported to. */
 internal data class LobbyMap(val instance: InstanceContainer, val spawn: Pos)
 
 internal object LobbyWorld {
     fun createInstance(): LobbyMap {
         val mapPath = Path.of(System.getenv("GROUNDS_LOBBY_MAP_PATH") ?: DEFAULT_MAP_PATH)
+        val world = mapPath.resolve(OVERWORLD).takeIf { Files.isDirectory(it) } ?: mapPath
 
-        val map = LoadedMap.load(mapPath)
-        val template = MapTemplate.build(map, true).join()
-        val provider = MapInstanceProvider(map, template)
-
-        val instanceContainer = provider.provision().instance()
-        val spawn = provider.spawn(0) ?: Pos(0.0, 40.0, 0.0)
+        val instanceContainer = MinecraftServer.getInstanceManager().createInstanceContainer()
+        instanceContainer.chunkLoader = AnvilLoader(world)
+        // The authored map ships no light data we can trust after Minestom rewrites blocks,
+        // so let it compute lighting per chunk.
+        instanceContainer.chunkSupplier = ChunkSupplier { instance, x, z ->
+            LightingChunk(instance, x, z)
+        }
 
         val clock = instanceContainer.defaultClock()!!
         clock.rate(0f)
         clock.time(SUNRISE_TIME)
 
-        return LobbyMap(instanceContainer, spawn)
+        return LobbyMap(instanceContainer, readSpawn(mapPath))
+    }
+
+    /**
+     * The spawn lives in the map's own `map.json` sidecar, next to the world data — the same file
+     * the gamemodes read. Duplicating it as a constant here would mean the map and the server could
+     * disagree about where the map's spawn is.
+     */
+    private fun readSpawn(mapPath: Path): Pos {
+        val sidecar = mapPath.resolve("map.json")
+        require(Files.isRegularFile(sidecar)) { "no map.json next to the lobby map at $mapPath" }
+
+        val spawns = JsonParser.parseString(Files.readString(sidecar)).asJsonObject["spawns"]
+        val spawn = spawns.asJsonArray.first().asJsonObject
+        return Pos(
+            spawn["x"].asDouble,
+            spawn["y"].asDouble,
+            spawn["z"].asDouble,
+            spawn["yaw"]?.asFloat ?: 0f,
+            spawn["pitch"]?.asFloat ?: 0f,
+        )
     }
 }


### PR DESCRIPTION
The 1.1.0 and 1.1.1 Docker builds both failed:

```
Could not find gg.grounds.vanilla:vanilla-maps:0.2.0.
```

`vanilla-maps` is published from the **private** `groundsgg/grounds-vanilla` repo, and the Docker build's token cannot read those packages (`plugin-permissions` works because that package grants this repo Actions access; `grounds-vanilla` does not). It resolved on my machine only because the jars were already in the Gradle cache — the same trap as before.

Rather than chase package permissions across repos, drop the dependency. The lobby has **one** map and **one** instance, so vanilla-maps' template/provisioning machinery buys it nothing:

- `AnvilLoader` (built into Minestom) pointed at `lobby/dimensions/minecraft/overworld` (the WorldDownloader layout puts region files one dimension deep)
- the spawn is read from the map's own `map.json`, so the map stays the single source of truth
- `LightingChunk` supplier kept — vanilla-maps used to install it for us

Build green (spotless, test, shadowJar).