### PR TITLE
feat(lobby): forward chat to the proxy so staff chat works

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.5.0")
+    // Forwards chat to the proxy, which owns the channels. Without it a Minestom server
+    // never sends a chat plugin message at all, so `!`-into-staff-chat silently does nothing.
+    implementation("gg.grounds:plugin-chat-minestom:0.1.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
## Why

Typing `!message` in the lobby was supposed to write into the network-wide staff chat. It did nothing.

The routing is on the proxy and works — `plugin-chat`'s `PluginMessageListener.routeToStaffChat` (I unzipped the jar in the running Velocity pod to be sure). It only fires when a backend server sends a `grounds:chat` plugin message. **The lobby never sent one, because it did not carry plugin-chat at all.**

## What

One dependency. The Minestom runtime discovers modules through `META-INF/services/gg.grounds.runtime.GroundsModuleProvider`, and `shadowJar` here already calls `mergeServiceFiles()`, so no code change is needed.

Verified against a locally-published build — the provider really does land in the merged SPI file of the fat jar:

```
$ unzip -p build/libs/*-all.jar META-INF/services/gg.grounds.runtime.GroundsModuleProvider
gg.grounds.permissions.minestom.GroundsPermissionsModuleProvider
gg.grounds.chat.minestom.GroundsChatModuleProvider     <-- new
gg.grounds.GroundsPluginAgonesProvider
```

Global chat stays **off** (`CHAT_GLOBAL_ENABLED` defaults to false), so ordinary lobby chat keeps being broadcast locally exactly as today. Only `!`-prefixed messages are forwarded to the proxy — which is where the `grounds.chat.staff` permission check lives, and where a non-staff message falls through to normal chat.

## Blocked on

groundsgg/plugin-chat#8 — makes the minestom module a discoverable runtime module *and* unbreaks Release Please (plugin-chat has never cut a release, which is why no `gg.grounds:plugin-chat-*` artifact exists in the org today).

The version here is pinned to **0.1.0**, the first release that PR will produce. If release-please lands a different number, this one line needs updating before merge.