### PR TITLE
feat: load the chat module in the lobby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,9 @@ on:
 jobs:
   reusable:
     uses: groundsgg/.github/.github/workflows/gradle-ci.yml@main
+    secrets:
+      # Read-only, and only for resolving plugin-chat-minestom: its Maven
+      # package is owned by the private plugin-chat repo, and this job's
+      # GITHUB_TOKEN is scoped to minestom-lobby alone. Unset falls back to
+      # GITHUB_TOKEN, so this line is inert until the secret exists.
+      PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}

--- a/.github/workflows/docker-gradle-build-push.yml
+++ b/.github/workflows/docker-gradle-build-push.yml
@@ -16,3 +16,9 @@ permissions:
 jobs:
   reusable:
     uses: groundsgg/.github/.github/workflows/docker-gradle-build-push.yml@main
+    secrets:
+      # Read-only, and only for resolving plugin-chat-minestom: its Maven
+      # package is owned by the private plugin-chat repo, and this job's
+      # GITHUB_TOKEN is scoped to minestom-lobby alone. Unset falls back to
+      # GITHUB_TOKEN, so this line is inert until the secret exists.
+      PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,3 +12,9 @@ permissions:
 jobs:
   reusable:
     uses: groundsgg/.github/.github/workflows/gradle-publish.yml@main
+    secrets:
+      # Read-only, and only for resolving plugin-chat-minestom: its Maven
+      # package is owned by the private plugin-chat repo, and this job's
+      # GITHUB_TOKEN is scoped to minestom-lobby alone. Unset falls back to
+      # GITHUB_TOKEN, so this line is inert until the secret exists.
+      PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.5.0")
+    // Discovered through the runtime's SPI, like the two above — there is no
+    // call site here. Without it the module is simply absent, and a `!`
+    // message is broadcast locally instead of being forwarded to the proxy's
+    // staff chat.
+    implementation("gg.grounds:plugin-chat-minestom:0.1.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Typing `!` in a lobby should reach network-wide staff chat. The proxy-side
routing has existed since plugin-chat#5 — the lobby just never sent it the
message, because the chat module was not on the classpath.

`plugin-chat`'s minestom module registers itself through the runtime's SPI, so
the dependency is the whole change; there is no call site here, exactly like
`plugin-agones` and `plugin-permissions`.

`0.1.0` is plugin-chat's **first** release. It only became publishable today:
release-please had failed on every push since 2026-07-12 with
`Missing required manifest config: release-please-config.json`, so no tag was
ever cut and no Maven artifact ever pushed.

### Verified locally, not just assumed

- `plugin-chat-minestom:0.1.0` resolves, pulling `plugin-chat-common` and
  `plugin-chat-api` transitively — the wildcard
  `maven.pkg.github.com/groundsgg/*` repository already in this build covers it,
  so no new repository entry was needed
- `./gradlew build` → `BUILD SUCCESSFUL`
- the shaded jar's merged
  `META-INF/services/gg.grounds.runtime.GroundsModuleProvider` contains
  `GroundsChatModuleProvider` next to the permissions and agones providers —
  which is what proves the module is discovered at runtime rather than merely
  present on the classpath

### After this

A lobby release, then the `lobby` image pin in `deploy` moves off 1.1.2. The
proxy half is groundsgg/deploy#11.