### PR TITLE
chore(deps): update permissions runtime to 0.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
-    implementation("gg.grounds:plugin-permissions-minestom:0.5.0")
+    implementation("gg.grounds:plugin-permissions-minestom:0.6.0")
     // Discovered through the runtime's SPI, like the two above — there is no
     // call site here. Without it the module is simply absent, and a `!`
     // message is broadcast locally instead of being forwarded to the proxy's


### PR DESCRIPTION
# Pull Request

## Description

Updates the Minestom permissions runtime dependency from 0.5.0 to 0.6.0 so the lobby can evaluate environment-scoped grants.

No source adaptation was required by the released API.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [x] 🔧 Chore

## Related Issues

- None

## Testing

- [x] Unit tests pass
- [x] Manual testing completed — dependencyInsight resolves plugin-permissions-minestom 0.6.0
- [ ] New tests added for new functionality
- [x] Spotless and full Gradle build pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass
- [x] Documentation has been updated where needed
