### PR TITLE
feat(permissions): use REST runtime client

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Use `GROUNDS_BIND_HOST`, `GROUNDS_BIND_PORT`, and `GROUNDS_SERVER_BRAND` to conf
 
 Use `./gradlew run` to run the server.
 
+### Permissions runtime
+
+Set both `PERMISSIONS_SERVICE_URL` and `PERMISSIONS_TOKEN_FILE` to enable the
+REST permissions provider. In Kubernetes, Forge and the `grounds-gamemode`
+chart supply these values together with the projected workload token. Leaving
+both unset disables the provider; partial configuration fails startup.
+
 ### As standalone
 
 Use `GROUNDS_PROXY_MODE=auto` with `GROUNDS_ONLINE_MODE=true` to run a standalone online-mode lobby.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
-    implementation("gg.grounds:plugin-permissions-minestom:0.6.0")
+    implementation("gg.grounds:plugin-permissions-minestom:0.7.0")
     // Discovered through the runtime's SPI, like the two above — there is no
     // call site here. Without it the module is simply absent, and a `!`
     // message is broadcast locally instead of being forwarded to the proxy's

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
@@ -30,7 +30,7 @@ internal fun selectedRuntimeProviderIds(env: Map<String, String> = System.getenv
         if (hasAgonesSidecar(env)) {
             add("grounds.agones")
         }
-        if (hasPermissionsTarget(env)) {
+        if (hasPermissionsRuntime(env)) {
             add("grounds.permissions")
         }
     }
@@ -38,5 +38,11 @@ internal fun selectedRuntimeProviderIds(env: Map<String, String> = System.getenv
 private fun hasAgonesSidecar(env: Map<String, String>): Boolean =
     !env["AGONES_SDK_HTTP_PORT"].isNullOrBlank() || !env["AGONES_SDK_GRPC_PORT"].isNullOrBlank()
 
-private fun hasPermissionsTarget(env: Map<String, String>): Boolean =
-    !env["PERMISSIONS_GRPC_TARGET"].isNullOrBlank()
+private fun hasPermissionsRuntime(env: Map<String, String>): Boolean {
+    val serviceUrl = env["PERMISSIONS_SERVICE_URL"]?.takeIf { it.isNotBlank() }
+    val tokenFile = env["PERMISSIONS_TOKEN_FILE"]?.takeIf { it.isNotBlank() }
+    check((serviceUrl == null) == (tokenFile == null)) {
+        "PERMISSIONS_SERVICE_URL and PERMISSIONS_TOKEN_FILE must be configured together"
+    }
+    return serviceUrl != null
+}

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
@@ -4,6 +4,7 @@ import gg.grounds.runtime.ServerType
 import gg.grounds.runtime.core.ProxyMode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -49,15 +50,32 @@ class LobbyRuntimeTest {
     }
 
     @Test
-    fun `lobby selects permissions provider only when permissions target is configured`() {
+    fun `lobby selects permissions provider only when REST runtime is fully configured`() {
         val standalone = selectedRuntimeProviderIds(emptyMap())
         val withPermissions =
             selectedRuntimeProviderIds(
-                mapOf("PERMISSIONS_GRPC_TARGET" to "service-permissions:9000")
+                mapOf(
+                    "PERMISSIONS_SERVICE_URL" to "http://service-permissions-runtime:8080",
+                    "PERMISSIONS_TOKEN_FILE" to "/var/run/secrets/grounds/permissions-token",
+                )
             )
 
         assertFalse(standalone.contains("grounds.permissions"))
         assertTrue(withPermissions.contains("grounds.permissions"))
+    }
+
+    @Test
+    fun `lobby rejects partial permissions REST runtime configuration`() {
+        assertThrows(IllegalStateException::class.java) {
+            selectedRuntimeProviderIds(
+                mapOf("PERMISSIONS_SERVICE_URL" to "http://service-permissions-runtime:8080")
+            )
+        }
+        assertThrows(IllegalStateException::class.java) {
+            selectedRuntimeProviderIds(
+                mapOf("PERMISSIONS_TOKEN_FILE" to "/var/run/secrets/grounds/permissions-token")
+            )
+        }
     }
 
     @Test
@@ -66,7 +84,8 @@ class LobbyRuntimeTest {
             selectedRuntimeProviderIds(
                 mapOf(
                     "AGONES_SDK_GRPC_PORT" to "9357",
-                    "PERMISSIONS_GRPC_TARGET" to "service-permissions:9000",
+                    "PERMISSIONS_SERVICE_URL" to "http://service-permissions-runtime:8080",
+                    "PERMISSIONS_TOKEN_FILE" to "/var/run/secrets/grounds/permissions-token",
                 )
             )
 


### PR DESCRIPTION
# Pull Request

## Description

Migrates the lobby permissions provider from the removed gRPC transport to the authenticated REST runtime.

- Pins `plugin-permissions-minestom` to `0.7.0`.
- Enables the provider only when `PERMISSIONS_SERVICE_URL` and `PERMISSIONS_TOKEN_FILE` are both configured.
- Rejects partial REST configuration during startup.
- Documents the runtime contract.

This is one producer in the coordinated permissions REST hardcut. It must be released before the platform bundle switches away from gRPC.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues

- None

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] New tests added for new functionality
- [x] `./gradlew test`
- [x] `./gradlew spotlessApply`
- [x] `./gradlew build`
- [x] Runtime dependency inspection contains no gRPC or Protobuf dependency

## Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
