### PR TITLE
feat: load the lobby navigator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,13 @@ repositories {
         }
     }
     maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/plugin-lobby")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
+    maven {
         url = uri("https://maven.pkg.github.com/groundsgg/*")
         credentials {
             username = providers.gradleProperty("github.user").get()
@@ -45,6 +52,10 @@ dependencies {
     // message is broadcast locally instead of being forwarded to the proxy's
     // staff chat.
     implementation("gg.grounds:plugin-chat-minestom:0.1.0")
+    // The locked inventory and the slot-9 navigator. Selected unconditionally in
+    // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
+    // player cannot leave except by disconnecting.
+    implementation("gg.grounds:plugin-lobby-minestom:0.1.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
@@ -27,6 +27,10 @@ internal fun lobbyRuntimeConfig(env: Map<String, String> = System.getenv()): Run
 
 internal fun selectedRuntimeProviderIds(env: Map<String, String> = System.getenv()): List<String> =
     buildList {
+        // Unconditional: the navigator talks to the proxy over the player's own connection, so
+        // there is no service to be configured and nothing to degrade to. Every other entry here
+        // is gated because it would fail without its backend; this one would only be missing.
+        add("grounds.lobby.navigator")
         if (hasAgonesSidecar(env)) {
             add("grounds.agones")
         }

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
@@ -89,6 +89,14 @@ class LobbyRuntimeTest {
                 )
             )
 
-        assertEquals(listOf("grounds.agones", "grounds.permissions"), providers)
+        assertEquals(
+            listOf("grounds.lobby.navigator", "grounds.agones", "grounds.permissions"),
+            providers,
+        )
+    }
+
+    @Test
+    fun `lobby always selects the navigator`() {
+        assertTrue(selectedRuntimeProviderIds(emptyMap()).contains("grounds.lobby.navigator"))
     }
 }


### PR DESCRIPTION
Wires in [groundsgg/plugin-lobby#1](https://github.com/groundsgg/plugin-lobby/pull/1): the
locked inventory and the slot-9 clock that switches lobby, zone or region.

Two changes plus a repository block:

- `implementation("gg.grounds:plugin-lobby-minestom:0.1.0")`
- `"grounds.lobby.navigator"` added to `selectedRuntimeProviderIds`, unconditionally

Unconditional because the navigator talks to the proxy over the player's own
connection — no backend to configure, nothing to degrade to. Gating it could
only ever make it missing.

## CI is red until plugin-lobby releases

`0.1.0` does not exist as a package yet. Verified locally against
`publishToMavenLocal -PversionOverride=0.1.0`: build green, and the runtime
composes it —

```
Building Grounds server (serverType=LOBBY, ..., providers=grounds.lobby.navigator,
                        discoveredProviderSelections=grounds.lobby.navigator)
```

Merge after plugin-lobby#1 lands and release-please cuts 0.1.0.

## Noticed, not fixed

`plugin-chat-minestom` is a dependency and registers `grounds.chat` over the SPI,
but nothing ever selects it — the runtime installs discovered providers only on
`useProvider(id)`, so the module is currently absent at runtime. The comment next
to the dependency says discovery is enough; it is not. Out of scope here.
