### PR TITLE
feat: zones and regions the navigator offers are now live

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:0.1.0")
+    implementation("gg.grounds:plugin-lobby-minestom:0.2.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 0.1.0 → 0.2.0 ([plugin-lobby#4](https://github.com/groundsgg/plugin-lobby/pull/4)).

The zone and region screens stop reading a configured catalogue and start listening: every lobby announces itself on `grounds.lobby.zones` every 15s, entries age out after 45s, and a region disappears when its last zone does. `NATS_URL` is already set on the lobby component.

No new configuration in this repo. A lobby announces only once it has been told its own zone, region and address, and `deploy`'s stage ApplicationSet passes no per-cluster values yet — so stage stays exactly as it is (one zone, nowhere to travel) until that plumbing lands.