### PR TITLE
fix: the navigator's clock actually appears

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:0.2.0")
+    implementation("gg.grounds:plugin-lobby-minestom:0.2.1")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 0.2.0 → 0.2.1 ([plugin-lobby#7](https://github.com/groundsgg/plugin-lobby/pull/7)).

Caught on stage — the clock never showed up:

```
java.lang.NoClassDefFoundError: gg/grounds/gui/ItemBuilder
	at gg.grounds.lobby.NavigatorItem.<clinit>
	at net.minestom.server.entity.Player.spawnPlayer
```

library-gui was `compileOnly` in plugin-lobby and nothing in this image supplies it, so it was absent at runtime. Minestom logs a throw from an event listener and carries on, so the server looked healthy and slot 9 was just empty.

No change needed here beyond the version.