### PR TITLE
fix: actually select the chat module, do not just ship it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,11 +47,12 @@ dependencies {
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.8.0")
-    // Discovered through the runtime's SPI, like the two above — there is no
-    // call site here. Without it the module is simply absent, and a `!`
-    // message is broadcast locally instead of being forwarded to the proxy's
-    // staff chat.
-    implementation("gg.grounds:plugin-chat-minestom:0.1.0")
+    // Reaches the runtime through the SPI, like the two above, so there is no call site here —
+    // but being on the classpath is not enough. Discovery only *lists* providers; a provider runs
+    // only if LobbyServer names it in useProvider(), and for a long time this one was not named.
+    // 0.2.0 is also the first version with the shared chat line, so a message looks the same
+    // whether it crossed the proxy or was broadcast inside this lobby.
+    implementation("gg.grounds:plugin-chat-minestom:0.2.0")
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyServer.kt
@@ -31,6 +31,12 @@ internal fun selectedRuntimeProviderIds(env: Map<String, String> = System.getenv
         // there is no service to be configured and nothing to degrade to. Every other entry here
         // is gated because it would fail without its backend; this one would only be missing.
         add("grounds.lobby.navigator")
+        // Unconditional for the same reason, and it was missing entirely: the dependency was
+        // declared and the provider was discovered, but never selected, so Minestom's own
+        // `<name> message` was what players actually saw and nothing ever reached the proxy.
+        // Like the navigator it needs no backend — with CHAT_GLOBAL_ENABLED unset it broadcasts
+        // inside this lobby instead of failing.
+        add("grounds.chat")
         if (hasAgonesSidecar(env)) {
             add("grounds.agones")
         }

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
@@ -40,6 +40,20 @@ class LobbyRuntimeTest {
         assertEquals("secret", config.proxy.velocityForwardingSecret)
     }
 
+    /**
+     * Chat was on the classpath and discovered by the SPI for months, but never named here, so
+     * players saw Minestom's own `<name> message` and nothing reached the proxy. Being discovered
+     * is not being selected — this is the test that would have caught it.
+     */
+    @Test
+    fun `lobby always selects chat, with or without any backend configured`() {
+        assertTrue(selectedRuntimeProviderIds(emptyMap()).contains("grounds.chat"))
+        assertTrue(
+            selectedRuntimeProviderIds(mapOf("AGONES_SDK_HTTP_PORT" to "9358"))
+                .contains("grounds.chat")
+        )
+    }
+
     @Test
     fun `lobby selects agones provider only when sidecar is detected`() {
         val standalone = selectedRuntimeProviderIds(emptyMap())
@@ -90,7 +104,12 @@ class LobbyRuntimeTest {
             )
 
         assertEquals(
-            listOf("grounds.lobby.navigator", "grounds.agones", "grounds.permissions"),
+            listOf(
+                "grounds.lobby.navigator",
+                "grounds.chat",
+                "grounds.agones",
+                "grounds.permissions",
+            ),
             providers,
         )
     }


### PR DESCRIPTION
Chat has never worked from a lobby. Not the formatting — the module.

Every lobby boot has logged this, and it says so plainly:

```
Discovered Grounds module providers: grounds.permissions@0.8.0, grounds.chat@0.1.0,
                                     grounds.lobby.navigator@0.2.0, grounds.agones@0.6.0
Activated Grounds modules: grounds.agones, grounds.lobby.navigator,
                           grounds.permissions, grounds.lobby
```

`grounds.chat` is in the first line and absent from the second.

`discoverProviders()` only **lists** what is on the classpath. A provider runs only if
`LobbyServer` names it in `useProvider()` — and chat never was. So `PlayerChatEvent`
was never cancelled, players saw Minestom's own `<name> message`, and nothing was
forwarded to the proxy. Network-wide chat from a lobby has never worked, and neither
has `!` staff chat, which is the thing the dependency was added for in the first place.

The dependency comment is where the assumption lived:

> Discovered through the runtime's SPI, like the two above — there is no call site here.

True about the SPI, wrong about the consequence. Being discovered is not being selected.

## The fix

`add("grounds.chat")`, unconditional — same rationale as the navigator: it needs no
backing service. With `CHAT_GLOBAL_ENABLED` unset it broadcasts inside the lobby
instead of failing, so there is nothing to gate on.

Also moves `plugin-chat-minestom` 0.1.0 → **0.2.0**, which is the first version with
the shared chat line, so a message looks the same whether it crossed the proxy or
stayed local.

A test now pins that chat is always selected, and the existing exact-list assertion is
updated rather than loosened — the order is part of what it checks.

## Still needed for network-wide chat

`CHAT_GLOBAL_ENABLED` defaults to **false** and is set nowhere in `groundsgg/deploy`.
With only this PR, chat becomes correctly formatted but stays local to each lobby.
Turning it on is a deploy change, landing separately.

## Verification

`./gradlew build` green — 8 tests, 1 new.