### PR TITLE
feat: the navigator offers regions, not datacentres

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:0.2.1")
+    implementation("gg.grounds:plugin-lobby-minestom:1.0.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 0.2.1 → 1.0.0 ([plugin-lobby#9](https://github.com/groundsgg/plugin-lobby/pull/9)).

The zone screen is gone. There is deliberately no address that means one datacentre and no other: `<continent>.geo.<domain>` is a single A record shared by every zone on the continent and round-robined between them. The navigator now offers the choice that actually exists.

The region screen goes live with charts `grounds-gamemode` 0.11.0, which renders `CONTINENT` and `GROUNDS_LOBBY_REGION_HOST`/`_PORT` from globals ArgoCD already passes.