### PR TITLE
feat: the lobby list shows player counts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.0.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.1.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.0.0 → 1.1.0 ([plugin-lobby#11](https://github.com/groundsgg/plugin-lobby/pull/11)).

The navigator's lobby list gets a player count per entry, asked over `grounds:lobby` and answered by plugin-proxy from `ProxyService.getNetworkPlayerCounts()`.

Needs **plugin-proxy 0.8.0** on the proxies. Without it the request simply goes unanswered — it sits outside the settle, so nothing waits and no numbers appear.