### PR TITLE
feat: translated menus and a lobby sidebar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.1.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.3.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.1.0 → 1.3.0. Two releases in one bump:

**1.2.0 — translations.** Every player-facing string in the navigator moves into a bundle rendered per player through library-i18n. Wording and colour change without a build ([plugin-lobby#13](https://github.com/groundsgg/plugin-lobby/pull/13)).

**1.3.0 — the sidebar.** Titled *Grounds*, then the player's name, their coins and their playtime ([plugin-lobby#16](https://github.com/groundsgg/plugin-lobby/pull/16)).

Worth knowing before it goes in: **coins render a dash and playtime counts this session.** Nothing on the platform stores a coin balance or a lifetime playtime, so there is nothing to read; a zero would be a claim that the player has none. Both become real by handing the scoreboard a source.