### PR TITLE
fix: the lobby starts again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.3.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.3.1")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.3.0 → 1.3.1.

1.3.0 died at boot:

```
Exception in thread "main" java.lang.NoClassDefFoundError:
    net/kyori/adventure/text/minimessage/MiniMessage
```

library-i18n declares MiniMessage `compileOnly` and Minestom supplies `adventure-api` without it, so nothing on the runtime classpath had it ([plugin-lobby#18](https://github.com/groundsgg/plugin-lobby/pull/18)).

Image 1.9.0 is affected — its GameServers never reach Ready. Players stayed on 1.8.0 throughout.