### PR TITLE
feat: playtime shows whole minutes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.3.1")
+    implementation("gg.grounds:plugin-lobby-minestom:1.4.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.3.1 → 1.4.0 ([plugin-lobby#20](https://github.com/groundsgg/plugin-lobby/pull/20)).

The sidebar's playtime line reads `125m` instead of `2h 05m`. The per-second task now skips when the minute has not changed — same cadence, a sixtieth of the packets.