### PR TITLE
feat: the sidebar shows name, region and playtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.4.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.5.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.3.1 → 1.5.0. Two releases in one bump:

**1.4.0** — playtime in whole minutes, and the per-second task skips when the minute has not changed ([plugin-lobby#20](https://github.com/groundsgg/plugin-lobby/pull/20)).

**1.5.0** — the layout ([plugin-lobby#22](https://github.com/groundsgg/plugin-lobby/pull/22)):

```
        Grounds
 2      dahendriik
 4      Region eu
 5      Playtime 12m
 8      grounds.gg
```

Colours are the Grounds palette rather than vanilla's named ones. Coins are gone — the layout has no line for them and nothing stores a balance yet.