### PR TITLE
feat: a compass with every registered game mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.5.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.6.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Bumps `plugin-lobby-minestom` 1.5.0 → 1.6.0 ([plugin-lobby#24](https://github.com/groundsgg/plugin-lobby/pull/24)).

A compass in the first hotbar slot lists every registered game mode and queues on click. The modes come from plugin-match over `grounds:match` ([plugin-match#1](https://github.com/groundsgg/plugin-match/pull/1), released 0.3.0) — they are an enum in that plugin, and a copy in the lobby would be a second list to keep in step.

Needs **plugin-match 0.3.0** on the proxies. Without it the menu is empty and nothing waits.