### PR TITLE
feat(deps): runtime 0.6.0 — the server can publish its own metrics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ repositories {
 dependencies {
     implementation(platform("gg.grounds:grounds-dependencies:1.0.0"))
 
-    implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.4.0")
+    implementation("gg.grounds:grounds-minestom-runtime-runtime-core:0.6.0")
     implementation("net.minestom:minestom")
     implementation("gg.grounds:plugin-agones-minestom:0.6.0")
     implementation("gg.grounds:plugin-permissions-minestom:0.8.0")


### PR DESCRIPTION
Bumps `grounds-minestom-runtime` to **0.6.0**, which adds a Prometheus endpoint to `runtime-core`: tick duration and thread acquisition, players, instances, entities, chunks, plus Micrometer's JVM and process binders under the same names the Quarkus services publish.

Dormant until `GROUNDS_METRICS_ENABLED` is set — `grounds-gamemode`'s `metrics.enabled` (charts#147) does that. This bump only puts the capability in the image.

`./gradlew build` green locally against 0.6.0.