### PR TITLE
feat: load the lobby world from the map service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,30 @@ Use `GROUNDS_PROXY_MODE=auto` with `GROUNDS_ONLINE_MODE=true` to run a standalon
 ## License
 
 Licensed under the GNU Affero General Public License v3.0
+
+## Where the world comes from
+
+By default the lobby loads the world baked into its image (`GROUNDS_LOBBY_MAP_PATH`, or `lobby/`
+next to the working directory).
+
+Set **`GROUNDS_LOBBY_MAP`** to a map address — `lobby/mainlobby` — and it instead loads the version
+pinned for its environment:
+
+| Variable | Meaning |
+|---|---|
+| `GROUNDS_LOBBY_MAP` | Map address to load. Unset keeps the baked-in world |
+| `MAPS_ENVIRONMENT` | Which pin file to read. Defaults to `stage` |
+| `MAPS_CDN_BASE` | CDN origin for the pin file. Defaults to `https://maps.grounds.gg` |
+| `MAPS_CACHE_DIR` | Where unpacked worlds are cached, keyed by digest |
+
+**The map service is never called.** It publishes `pins/<env>.json` to the CDN and that file names
+the content-addressed bundle, so a lobby boots and loads its world with the registry down. Bundles
+are immutable and cached under their own digest, so a restart that changes nothing downloads
+nothing.
+
+If anything fails — no pin, no network, a broken bundle — the lobby **starts on the world it
+shipped with** and says so in the log. An empty lobby is worse than a slightly old one.
+
+The spawn comes from `grounds/pois.json` inside the world, which is what a builder marked with
+`/ms spawn` on the build server. A world published before points existed falls back to the map
+template's first spawn.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")
+    // Fetching and unpacking the pinned bundle: the same tar.zst the build server produces.
+    implementation("org.apache.commons:commons-compress:1.28.0")
+    implementation("com.github.luben:zstd-jni:1.5.7-6")
+    implementation("com.google.code.gson:gson:2.13.2")
     implementation("org.slf4j:slf4j-api")
 
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyPoints.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyPoints.kt
@@ -23,17 +23,19 @@ internal object LobbyPoints {
             return null
         }
         return runCatching {
-            val pois =
-                JsonParser.parseString(Files.readString(file)).asJsonObject.getAsJsonObject("pois")
-            val poi = pois?.getAsJsonObject(name) ?: return null
-            Pos(
-                poi.get("x").asDouble,
-                poi.get("y").asDouble,
-                poi.get("z").asDouble,
-                poi.get("yaw").asFloat,
-                poi.get("pitch").asFloat,
-            )
-        }
+                val pois =
+                    JsonParser.parseString(Files.readString(file))
+                        .asJsonObject
+                        .getAsJsonObject("pois")
+                val poi = pois?.getAsJsonObject(name) ?: return null
+                Pos(
+                    poi.get("x").asDouble,
+                    poi.get("y").asDouble,
+                    poi.get("z").asDouble,
+                    poi.get("yaw").asFloat,
+                    poi.get("pitch").asFloat,
+                )
+            }
             .onFailure { logger.warn("Could not read {} from {}", name, file, it) }
             .getOrNull()
     }

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyPoints.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyPoints.kt
@@ -1,0 +1,40 @@
+package gg.grounds.minestom.lobby
+
+import com.google.gson.JsonParser
+import java.nio.file.Files
+import java.nio.file.Path
+import net.minestom.server.coordinate.Pos
+import org.slf4j.LoggerFactory
+
+/**
+ * The places a builder marked in the map, read from `grounds/pois.json` inside the world.
+ *
+ * The file travels in the bundle, so the spawn a version was published with is the spawn that
+ * version has — there is no second store to keep in step with whichever version is live.
+ */
+internal object LobbyPoints {
+
+    private val logger = LoggerFactory.getLogger(LobbyPoints::class.java)
+
+    /** The named point, or null when the map carries none. Never throws: a lobby has a fallback. */
+    fun read(worldFolder: Path, name: String): Pos? {
+        val file = worldFolder.resolve("grounds").resolve("pois.json")
+        if (!Files.isRegularFile(file)) {
+            return null
+        }
+        return runCatching {
+            val pois =
+                JsonParser.parseString(Files.readString(file)).asJsonObject.getAsJsonObject("pois")
+            val poi = pois?.getAsJsonObject(name) ?: return null
+            Pos(
+                poi.get("x").asDouble,
+                poi.get("y").asDouble,
+                poi.get("z").asDouble,
+                poi.get("yaw").asFloat,
+                poi.get("pitch").asFloat,
+            )
+        }
+            .onFailure { logger.warn("Could not read {} from {}", name, file, it) }
+            .getOrNull()
+    }
+}

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
@@ -18,7 +18,10 @@ private const val SUNRISE_TIME: Long = 6000
 // right next to build.gradle.kts), so the same default works in both places.
 private const val DEFAULT_MAP_PATH = "lobby"
 
-/** The map address to pull from the registry, e.g. `lobby/mainlobby`. Unset keeps the baked-in world. */
+/**
+ * The map address to pull from the registry, e.g. `lobby/mainlobby`. Unset keeps the baked-in
+ * world.
+ */
 private const val MAP_ADDRESS_ENV = "GROUNDS_LOBBY_MAP"
 
 /** What a builder marks with `/ms spawn` on the build server. */

--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
@@ -18,10 +18,34 @@ private const val SUNRISE_TIME: Long = 6000
 // right next to build.gradle.kts), so the same default works in both places.
 private const val DEFAULT_MAP_PATH = "lobby"
 
+/** The map address to pull from the registry, e.g. `lobby/mainlobby`. Unset keeps the baked-in world. */
+private const val MAP_ADDRESS_ENV = "GROUNDS_LOBBY_MAP"
+
+/** What a builder marks with `/ms spawn` on the build server. */
+private const val SPAWN_POINT = "spawn"
+
 // The map was exported by WorldDownloader, which puts the region files one dimension deep
 // rather than in a top-level region/. AnvilLoader wants the directory that *contains*
 // region/, so descend when that layout is what we got.
 private const val OVERWORLD = "dimensions/minecraft/overworld"
+
+/**
+ * Where the world comes from: the pinned version in the map service when `GROUNDS_LOBBY_MAP` names
+ * a map, otherwise the folder baked into the image.
+ *
+ * The fallback is not politeness. A lobby that cannot reach the CDN should still start and serve
+ * players on the world it shipped with — an empty lobby is worse than a slightly old one, and the
+ * log says which it got.
+ */
+private fun resolveMapPath(): Path {
+    val address = System.getenv(MAP_ADDRESS_ENV)
+    if (!address.isNullOrBlank()) {
+        MapDistribution().worldFor(address)?.let {
+            return it
+        }
+    }
+    return Path.of(System.getenv("GROUNDS_LOBBY_MAP_PATH") ?: DEFAULT_MAP_PATH)
+}
 
 /** The loaded lobby instance and the spawn every joining player is teleported to. */
 internal data class LobbyMap(val instance: InstanceContainer, val spawn: Pos)

--- a/src/main/kotlin/gg/grounds/minestom/lobby/MapDistribution.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/MapDistribution.kt
@@ -40,8 +40,7 @@ internal class MapDistribution(
 
     private val logger = LoggerFactory.getLogger(MapDistribution::class.java)
 
-    private val http =
-        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build()
+    private val http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build()
 
     /** What the pin file says about one map. */
     data class Pinned(val version: Int, val bundleSha256: String, val bundleUrl: String)
@@ -55,16 +54,21 @@ internal class MapDistribution(
      */
     fun worldFor(address: String): Path? =
         runCatching {
-            val pinned = pin(address) ?: return null
-            val unpacked = cacheDir.resolve(pinned.bundleSha256)
-            if (Files.isDirectory(unpacked)) {
-                logger.info("Using cached {} v{} ({})", address, pinned.version, short(pinned.bundleSha256))
-                return unpacked
+                val pinned = pin(address) ?: return null
+                val unpacked = cacheDir.resolve(pinned.bundleSha256)
+                if (Files.isDirectory(unpacked)) {
+                    logger.info(
+                        "Using cached {} v{} ({})",
+                        address,
+                        pinned.version,
+                        short(pinned.bundleSha256),
+                    )
+                    return unpacked
+                }
+                download(pinned, unpacked)
+                logger.info("Loaded {} v{} from the map service", address, pinned.version)
+                unpacked
             }
-            download(pinned, unpacked)
-            logger.info("Loaded {} v{} from the map service", address, pinned.version)
-            unpacked
-        }
             .onFailure { logger.warn("Could not get {} from the map service", address, it) }
             .getOrNull()
 
@@ -72,7 +76,10 @@ internal class MapDistribution(
         val url = "${cdnBase.trimEnd('/')}/pins/$environment.json"
         val response =
             http.send(
-                HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(30)).GET().build(),
+                HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build(),
                 HttpResponse.BodyHandlers.ofString(),
             )
         if (response.statusCode() != 200) {
@@ -95,7 +102,8 @@ internal class MapDistribution(
     private fun download(pinned: Pinned, target: Path) {
         // Unpacked beside the target and moved into place: a half-extracted world that another
         // boot mistakes for a cache hit is a lobby with holes in it.
-        val staging = Files.createTempDirectory(cacheDir.also { Files.createDirectories(it) }, "unpacking-")
+        val staging =
+            Files.createTempDirectory(cacheDir.also { Files.createDirectories(it) }, "unpacking-")
         try {
             http
                 .send(
@@ -107,18 +115,21 @@ internal class MapDistribution(
                 )
                 .body()
                 .use { body ->
-                    TarArchiveInputStream(ZstdCompressorInputStream(BufferedInputStream(body))).use { tar ->
-                        generateSequence { tar.nextEntry }
-                            .filter { !it.isDirectory }
-                            .forEach { entry ->
-                                val file = staging.resolve(entry.name).normalize()
-                                // A bundle is fetched over the network; an entry named `../..`
-                                // would write outside the cache directory entirely.
-                                require(file.startsWith(staging)) { "bundle entry escapes: ${entry.name}" }
-                                Files.createDirectories(file.parent)
-                                Files.newOutputStream(file).use { tar.copyTo(it) }
-                            }
-                    }
+                    TarArchiveInputStream(ZstdCompressorInputStream(BufferedInputStream(body)))
+                        .use { tar ->
+                            generateSequence { tar.nextEntry }
+                                .filter { !it.isDirectory }
+                                .forEach { entry ->
+                                    val file = staging.resolve(entry.name).normalize()
+                                    // A bundle is fetched over the network; an entry named `../..`
+                                    // would write outside the cache directory entirely.
+                                    require(file.startsWith(staging)) {
+                                        "bundle entry escapes: ${entry.name}"
+                                    }
+                                    Files.createDirectories(file.parent)
+                                    Files.newOutputStream(file).use { tar.copyTo(it) }
+                                }
+                        }
                 }
             Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE)
         } catch (failure: Exception) {

--- a/src/main/kotlin/gg/grounds/minestom/lobby/MapDistribution.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/MapDistribution.kt
@@ -1,0 +1,137 @@
+package gg.grounds.minestom.lobby
+
+import com.google.gson.JsonParser
+import java.io.BufferedInputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.Duration
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream
+import org.slf4j.LoggerFactory
+
+/**
+ * Fetches the pinned lobby world from the map service's CDN read path.
+ *
+ * **The registry itself is never called.** It publishes `pins/<env>.json` to the CDN, and that file
+ * names — per map address — the content-addressed bundle to fetch. A lobby therefore boots and
+ * loads its world with service-maps down, which is the point of the design rather than a happy
+ * accident.
+ *
+ * Bundles are immutable and named by their own digest, so an unpacked copy is cached under that
+ * digest and never fetched twice. A restart that changes nothing costs nothing.
+ *
+ * @param cdnBase CDN origin. First-party and creator content are served from different hosts, and
+ *   the pin file carries absolute bundle URLs for exactly that reason — this is only the fallback
+ *   for reading the pin file itself.
+ * @param environment which pin file to read, and therefore which version players get. Read from
+ *   `MAPS_ENVIRONMENT`, deliberately not `GROUNDS_ENV`: that one belongs to the runtime and accepts
+ *   only prod/test/dev, while a pin file is named after a deployment environment such as `stage`.
+ */
+internal class MapDistribution(
+    private val cdnBase: String = System.getenv("MAPS_CDN_BASE") ?: DEFAULT_CDN_BASE,
+    private val environment: String = System.getenv("MAPS_ENVIRONMENT") ?: DEFAULT_ENVIRONMENT,
+    private val cacheDir: Path = Path.of(System.getenv("MAPS_CACHE_DIR") ?: DEFAULT_CACHE_DIR),
+) {
+
+    private val logger = LoggerFactory.getLogger(MapDistribution::class.java)
+
+    private val http =
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build()
+
+    /** What the pin file says about one map. */
+    data class Pinned(val version: Int, val bundleSha256: String, val bundleUrl: String)
+
+    /**
+     * The unpacked world folder for [address], or null when anything at all goes wrong.
+     *
+     * Null rather than an exception on purpose: a lobby that cannot reach the CDN should start on
+     * the world baked into its image and serve players, not fail to boot. The caller logs which
+     * world it ended up with, so "the update did not take" is visible without being fatal.
+     */
+    fun worldFor(address: String): Path? =
+        runCatching {
+            val pinned = pin(address) ?: return null
+            val unpacked = cacheDir.resolve(pinned.bundleSha256)
+            if (Files.isDirectory(unpacked)) {
+                logger.info("Using cached {} v{} ({})", address, pinned.version, short(pinned.bundleSha256))
+                return unpacked
+            }
+            download(pinned, unpacked)
+            logger.info("Loaded {} v{} from the map service", address, pinned.version)
+            unpacked
+        }
+            .onFailure { logger.warn("Could not get {} from the map service", address, it) }
+            .getOrNull()
+
+    private fun pin(address: String): Pinned? {
+        val url = "${cdnBase.trimEnd('/')}/pins/$environment.json"
+        val response =
+            http.send(
+                HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(30)).GET().build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+        if (response.statusCode() != 200) {
+            logger.warn("Pin file {} answered HTTP {}", url, response.statusCode())
+            return null
+        }
+        val maps = JsonParser.parseString(response.body()).asJsonObject.getAsJsonObject("maps")
+        val entry = maps?.getAsJsonObject(address)
+        if (entry == null) {
+            logger.warn("No pin for {} in {}", address, environment)
+            return null
+        }
+        return Pinned(
+            version = entry.get("version").asInt,
+            bundleSha256 = entry.get("bundleSha256").asString,
+            bundleUrl = entry.get("bundleUrl").asString,
+        )
+    }
+
+    private fun download(pinned: Pinned, target: Path) {
+        // Unpacked beside the target and moved into place: a half-extracted world that another
+        // boot mistakes for a cache hit is a lobby with holes in it.
+        val staging = Files.createTempDirectory(cacheDir.also { Files.createDirectories(it) }, "unpacking-")
+        try {
+            http
+                .send(
+                    HttpRequest.newBuilder(URI.create(pinned.bundleUrl))
+                        .timeout(Duration.ofMinutes(10))
+                        .GET()
+                        .build(),
+                    HttpResponse.BodyHandlers.ofInputStream(),
+                )
+                .body()
+                .use { body ->
+                    TarArchiveInputStream(ZstdCompressorInputStream(BufferedInputStream(body))).use { tar ->
+                        generateSequence { tar.nextEntry }
+                            .filter { !it.isDirectory }
+                            .forEach { entry ->
+                                val file = staging.resolve(entry.name).normalize()
+                                // A bundle is fetched over the network; an entry named `../..`
+                                // would write outside the cache directory entirely.
+                                require(file.startsWith(staging)) { "bundle entry escapes: ${entry.name}" }
+                                Files.createDirectories(file.parent)
+                                Files.newOutputStream(file).use { tar.copyTo(it) }
+                            }
+                    }
+                }
+            Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE)
+        } catch (failure: Exception) {
+            staging.toFile().deleteRecursively()
+            throw failure
+        }
+    }
+
+    private fun short(digest: String) = digest.take(12)
+
+    private companion object {
+        const val DEFAULT_CDN_BASE = "https://maps.grounds.gg"
+        const val DEFAULT_ENVIRONMENT = "stage"
+        const val DEFAULT_CACHE_DIR = "/tmp/grounds-maps"
+    }
+}

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyPointsTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyPointsTest.kt
@@ -1,0 +1,62 @@
+package gg.grounds.minestom.lobby
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class LobbyPointsTest {
+
+    @TempDir lateinit var world: Path
+
+    /**
+     * The builder stood where players should land and marked it. That has to survive the trip
+     * through the bundle, facing included — a spawn that drops players into a wall is a bug report
+     * nobody can explain from coordinates alone.
+     */
+    @Test
+    fun `reads the spawn a builder marked`() {
+        world.resolve("grounds").createDirectories()
+        world
+            .resolve("grounds/pois.json")
+            .writeText(
+                """{"format":1,"pois":{"spawn":{"x":10.5,"y":64.0,"z":-3.5,"yaw":90.0,"pitch":-12.5}}}"""
+            )
+
+        val spawn = LobbyPoints.read(world, "spawn")
+
+        assertEquals(10.5, spawn!!.x())
+        assertEquals(64.0, spawn.y())
+        assertEquals(-3.5, spawn.z())
+        assertEquals(90.0f, spawn.yaw())
+        assertEquals(-12.5f, spawn.pitch())
+    }
+
+    /** A world published before points existed simply has none; the caller falls back. */
+    @Test
+    fun `a map without points reads as null`() {
+        assertNull(LobbyPoints.read(world, "spawn"))
+    }
+
+    /** A broken file must not stop a lobby from starting — an old world beats no world. */
+    @Test
+    fun `a corrupt file reads as null rather than throwing`() {
+        world.resolve("grounds").createDirectories()
+        world.resolve("grounds/pois.json").writeText("{ not json")
+
+        assertNull(LobbyPoints.read(world, "spawn"))
+    }
+
+    @Test
+    fun `a point the map does not carry reads as null`() {
+        world.resolve("grounds").createDirectories()
+        world.resolve("grounds/pois.json").writeText("""{"format":1,"pois":{"other":{"x":0,"y":0,"z":0,"yaw":0,"pitch":0}}}""")
+
+        assertNull(LobbyPoints.read(world, "spawn"))
+        Files.deleteIfExists(world.resolve("grounds/pois.json"))
+    }
+}

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyPointsTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyPointsTest.kt
@@ -54,7 +54,9 @@ class LobbyPointsTest {
     @Test
     fun `a point the map does not carry reads as null`() {
         world.resolve("grounds").createDirectories()
-        world.resolve("grounds/pois.json").writeText("""{"format":1,"pois":{"other":{"x":0,"y":0,"z":0,"yaw":0,"pitch":0}}}""")
+        world
+            .resolve("grounds/pois.json")
+            .writeText("""{"format":1,"pois":{"other":{"x":0,"y":0,"z":0,"yaw":0,"pitch":0}}}""")
 
         assertNull(LobbyPoints.read(world, "spawn"))
         Files.deleteIfExists(world.resolve("grounds/pois.json"))


### PR DESCRIPTION
A map pushed from the build server reached nobody: the lobby ran the world **baked into its image**.

With `GROUNDS_LOBBY_MAP=lobby/mainlobby` it now loads the version pinned for its environment.

## How

The **registry is never called**. It publishes `pins/<env>.json` to the CDN, and that file names the content-addressed bundle — so a lobby boots and loads its world with service-maps down, which is the point of that design. Bundles are immutable, so the unpacked copy is cached under its own digest and a restart that changes nothing downloads nothing.

Unpacking happens beside the target and moves into place: a half-extracted world that the next boot mistakes for a cache hit is a lobby with holes in it. Entries are checked against path escape, because a bundle arrives over the network.

## Failure is not fatal

No pin, no network, a broken bundle — the lobby **starts on the world it shipped with** and logs which one it got. An empty lobby is worse than a slightly old one, and one that refuses to boot because a CDN is unreachable is worse than both.

## The spawn comes from the map

`grounds/pois.json` is what a builder marked with `/ms spawn`. It travels in the bundle, so a version carries the spawn it was published with — facing included, since a spawn that drops players into a wall cannot be explained from coordinates alone. A world published before points existed falls back to the map template's first spawn.

4 new tests on the point reading, 8/8 green.