### PR TITLE
fix: actually use the map service path

### DIFF
--- a/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
+++ b/src/main/kotlin/gg/grounds/minestom/lobby/LobbyWorld.kt
@@ -55,7 +55,7 @@ internal data class LobbyMap(val instance: InstanceContainer, val spawn: Pos)
 
 internal object LobbyWorld {
     fun createInstance(): LobbyMap {
-        val mapPath = Path.of(System.getenv("GROUNDS_LOBBY_MAP_PATH") ?: DEFAULT_MAP_PATH)
+        val mapPath = resolveMapPath()
         val world = mapPath.resolve(OVERWORLD).takeIf { Files.isDirectory(it) } ?: mapPath
 
         val instanceContainer = MinecraftServer.getInstanceManager().createInstanceContainer()
@@ -70,17 +70,27 @@ internal object LobbyWorld {
         clock.rate(0f)
         clock.time(SUNRISE_TIME)
 
-        return LobbyMap(instanceContainer, readSpawn(mapPath))
+        return LobbyMap(instanceContainer, spawnFor(mapPath))
     }
 
     /**
-     * The spawn lives in the map's own `map.json` sidecar, next to the world data — the same file
-     * the gamemodes read. Duplicating it as a constant here would mean the map and the server could
-     * disagree about where the map's spawn is.
+     * Where players land, from the map itself — never a constant here, or the map and the server
+     * could disagree about the map's own spawn.
+     *
+     * Two sources, in order: the point a builder marked with `/ms spawn`, which travels inside the
+     * bundle in `grounds/pois.json`; then the `map.json` sidecar an exported world carries. A map
+     * from the registry has no sidecar, so requiring one would kill the lobby at boot the moment it
+     * loads a published version — which is exactly what this server is now pointed at.
      */
-    private fun readSpawn(mapPath: Path): Pos {
+    private fun spawnFor(mapPath: Path): Pos =
+        LobbyPoints.read(mapPath, SPAWN_POINT) ?: readSidecarSpawn(mapPath)
+
+    private fun readSidecarSpawn(mapPath: Path): Pos {
         val sidecar = mapPath.resolve("map.json")
-        require(Files.isRegularFile(sidecar)) { "no map.json next to the lobby map at $mapPath" }
+        require(Files.isRegularFile(sidecar)) {
+            "the lobby map at $mapPath carries neither grounds/pois.json nor map.json, so nothing" +
+                " says where players should land"
+        }
 
         val spawns = JsonParser.parseString(Files.readString(sidecar)).asJsonObject["spawns"]
         val spawn = spawns.asJsonArray.first().asJsonObject


### PR DESCRIPTION
**The lobby is still serving the world baked into its image**, despite `GROUNDS_LOBBY_MAP=lobby/mainlobby` being set on every pod.

Two changes landed on `createInstance()` at the same time — the registry lookup from #69 and a rewrite to `AnvilLoader` with per-chunk lighting. The merge kept both **side by side**: `resolveMapPath()` survived and nothing called it. No log line either way, because the code that logs never ran.

Verified on the satellite before changing anything: all four lobby pods run `1.14.0` with the env set, and their logs contain no map-service line at all.

## The spawn, and a boot-time trap

`readSpawn` **required** a `map.json` sidecar. A map from the registry has none — so pointing the lobby at a published version would have killed it at startup. The spawn now prefers the point a builder marked with `/ms spawn` (which travels inside the bundle as `grounds/pois.json`) and falls back to the sidecar an exported world carries. Neither present is still an error, with a message that says what is missing.