### PR TITLE
feat(lobby): plugin-lobby 1.7.0 — the duel menu

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.
-    implementation("gg.grounds:plugin-lobby-minestom:1.6.0")
+    implementation("gg.grounds:plugin-lobby-minestom:1.7.0")
     // Reads the map's map.json sidecar (the spawn). Minestom pulls gson in transitively;
     // declare it because we use it directly.
     implementation("com.google.code.gson:gson:2.13.2")


### PR DESCRIPTION
Picks up groundsgg/plugin-lobby#26.

duel now registers eighteen queues — nine kits, ranked and casual — and the compass lists whatever the proxy reports, so today they arrive as eighteen flat rows and bury BedWars under four pages of "Sword (Ranked)".

With this they fold into a single **Duels** entry that opens a menu of its own: ranked and casual as the first two slots, the nine kits below, each shown as its own weapon (mace kit = mace, bow kit = bow), with the queue depth per kit.

No theming — the menu uses vanilla item icons. A resource pack needs artwork and somewhere to host it, neither of which exists yet.