### PR TITLE
feat(chat): enable player reporting in lobby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Minestom Lobby
 
 This is a simple lobby built on Minestom.
- 
+
 Following features are implemented:
 
 - Official skins are loaded
@@ -10,19 +10,24 @@ Following features are implemented:
 - Server startup is delegated to `grounds-minestom-runtime`
 - Auth and profile forwarding are configured through `grounds-minestom-runtime`
 
-## Running 
+## Running
 
 Use `GROUNDS_BIND_HOST`, `GROUNDS_BIND_PORT`, and `GROUNDS_SERVER_BRAND` to configure the server.
 
 ### Behind Velocity
 
 1. In Velocity, got to the `velocity.toml` and change `player-info-forwarding-mode` to `modern`.
-(Example: `player-info-forwarding-mode = "modern"`).
+   (Example: `player-info-forwarding-mode = "modern"`).
 2. Add the server to the `servers` section.
 3. Configure runtime proxy auth with `GROUNDS_PROXY_MODE=velocity`.
 4. Set `GROUNDS_VELOCITY_FORWARDING_SECRET` to the content of Velocity's `forwarding.secret`.
 
-Use `./gradlew run` to run the server.
+Launch the lobby group with shared chat enabled:
+
+```shell
+# Lobby group behind Velocity
+CHAT_GLOBAL_ENABLED=true CHAT_GROUP=lobby ./gradlew run
+```
 
 ### Permissions runtime
 
@@ -34,6 +39,11 @@ both unset disables the provider; partial configuration fails startup.
 ### As standalone
 
 Use `GROUNDS_PROXY_MODE=auto` with `GROUNDS_ONLINE_MODE=true` to run a standalone online-mode lobby.
+
+```shell
+# Standalone local chat
+CHAT_GLOBAL_ENABLED=false CHAT_GROUP= ./gradlew run
+```
 
 ## License
 
@@ -47,12 +57,12 @@ next to the working directory).
 Set **`GROUNDS_LOBBY_MAP`** to a map address — `lobby/mainlobby` — and it instead loads the version
 pinned for its environment:
 
-| Variable | Meaning |
-|---|---|
-| `GROUNDS_LOBBY_MAP` | Map address to load. Unset keeps the baked-in world |
-| `MAPS_ENVIRONMENT` | Which pin file to read. Defaults to `stage` |
-| `MAPS_CDN_BASE` | CDN origin for the pin file. Defaults to `https://maps.grounds.gg` |
-| `MAPS_CACHE_DIR` | Where unpacked worlds are cached, keyed by digest |
+| Variable            | Meaning                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `GROUNDS_LOBBY_MAP` | Map address to load. Unset keeps the baked-in world                |
+| `MAPS_ENVIRONMENT`  | Which pin file to read. Defaults to `stage`                        |
+| `MAPS_CDN_BASE`     | CDN origin for the pin file. Defaults to `https://maps.grounds.gg` |
+| `MAPS_CACHE_DIR`    | Where unpacked worlds are cached, keyed by digest                  |
 
 **The map service is never called.** It publishes `pins/<env>.json` to the CDN and that file names
 the content-addressed bundle, so a lobby boots and loads its world with the registry down. Bundles

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     // only if LobbyServer names it in useProvider(), and for a long time this one was not named.
     // 0.2.0 is also the first version with the shared chat line, so a message looks the same
     // whether it crossed the proxy or was broadcast inside this lobby.
-    implementation("gg.grounds:plugin-chat-minestom:0.2.0")
+    implementation("gg.grounds:plugin-chat-minestom:1.1.0")
     // The locked inventory and the slot-9 navigator. Selected unconditionally in
     // LobbyServer: it needs no backing service, and a lobby without it is a lobby a
     // player cannot leave except by disconnecting.

--- a/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
+++ b/src/test/kotlin/gg/grounds/minestom/lobby/LobbyRuntimeTest.kt
@@ -55,6 +55,14 @@ class LobbyRuntimeTest {
     }
 
     @Test
+    fun `lobby selects navigator before chat without backend configuration`() {
+        assertEquals(
+            listOf("grounds.lobby.navigator", "grounds.chat"),
+            selectedRuntimeProviderIds(emptyMap()),
+        )
+    }
+
+    @Test
     fun `lobby selects agones provider only when sidecar is detected`() {
         val standalone = selectedRuntimeProviderIds(emptyMap())
         val withAgones = selectedRuntimeProviderIds(mapOf("AGONES_SDK_HTTP_PORT" to "9358"))


### PR DESCRIPTION
# Pull Request

## Description

Enable the released player-reporting module in the lobby by upgrading
`plugin-chat-minestom` to `1.1.0`. The runtime-provider tests now lock the
standalone provider order to `grounds.lobby.navigator`, then `grounds.chat`.

The README documents the explicit standalone local-chat and Velocity lobby-group
launch modes. The lobby remains a thin runtime composition: Moderation REST,
NATS permissions, and deployment-specific chat values stay outside this repo.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues

- Closes #73

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] New tests added for new functionality

Validation completed:

- `./gradlew dependencyInsight --dependency plugin-chat-minestom --configuration runtimeClasspath`
- `./gradlew test --rerun-tasks`
- `./gradlew spotlessApply`
- `./gradlew build`
- Bounded Minecraft 26.2 two-client smoke in standalone local-chat mode
- Bounded Minecraft 26.2 two-client smoke through Velocity and local NATS, with exactly one shared group-chat line observed per client
- Invalid `CHAT_GLOBAL_ENABLED=false` plus `CHAT_GROUP=lobby` configuration rejected before server startup

## Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
